### PR TITLE
[express-fileupload] missing types

### DIFF
--- a/types/express-fileupload/index.d.ts
+++ b/types/express-fileupload/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for express-fileupload 0.4
+// Type definitions for express-fileupload 1.1
 // Project: https://github.com/richardgirges/express-fileupload#readme
 // Definitions by: Gintautas Miselis <https://github.com/Naktibalda>
 //                 Sefa Ilkimen <https://github.com/silkimen>
+//                 Tomas Vosicky <https://github.com/vosatom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -29,7 +30,10 @@ declare namespace fileUpload {
         encoding: string;
         mimetype: string;
         data: Buffer;
+        size: number;
+        tempFilePath: string;
         truncated: boolean;
+        md5: string;
         mv(path: string, callback: (err: any) => void): void;
         mv(path: string): Promise<void>;
     }


### PR DESCRIPTION
- express-fileupload@1.1.x added `md5` to `UploadedFile`
- `size` and `tempFilePath` was missing

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation - https://github.com/richardgirges/express-fileupload/tree/master
- [x] Increase the version number in the header if appropriate.
